### PR TITLE
Enable headless browser testing for WASM and Node.js

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
             }
         }
         nodejs()
+        binaries.executable()
     }
     js {
         browser {
@@ -48,6 +49,7 @@ kotlin {
             }
         }
         nodejs()
+        binaries.executable()
     }
 
     sourceSets {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -27,7 +27,17 @@ kotlin {
     iosSimulatorArm64()
     linuxX64()
     @OptIn(ExperimentalWasmDsl::class)
-    wasmJs()
+    wasmJs {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                    useFirefoxHeadless()
+                }
+            }
+        }
+        nodejs()
+    }
     js {
         browser {
             testTask {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -37,7 +37,6 @@ kotlin {
             }
         }
         nodejs()
-        binaries.executable()
     }
     js {
         browser {
@@ -49,7 +48,6 @@ kotlin {
             }
         }
         nodejs()
-        binaries.executable()
     }
 
     sourceSets {


### PR DESCRIPTION
Updated the `wasmJs` configuration to support testing with karma using headless Chrome and Firefox. Added Node.js support in the `wasmJs` block to diversify the testing environments. This ensures better compatibility and more comprehensive test coverage for the project.